### PR TITLE
Feature/script install docker

### DIFF
--- a/src/main/docker/get.docker.com.sh
+++ b/src/main/docker/get.docker.com.sh
@@ -1,0 +1,489 @@
+#!/bin/sh
+set -e
+#
+# This script is meant for quick & easy install via:
+#   'curl -sSL https://get.docker.com/ | sh'
+# or:
+#   'wget -qO- https://get.docker.com/ | sh'
+#
+# For test builds (ie. release candidates):
+#   'curl -fsSL https://test.docker.com/ | sh'
+# or:
+#   'wget -qO- https://test.docker.com/ | sh'
+#
+# For experimental builds:
+#   'curl -fsSL https://experimental.docker.com/ | sh'
+# or:
+#   'wget -qO- https://experimental.docker.com/ | sh'
+#
+# Docker Maintainers:
+#   To update this script on https://get.docker.com,
+#   use hack/release.sh during a normal release,
+#   or the following one-liner for script hotfixes:
+#     s3cmd put --acl-public -P hack/install.sh s3://get.docker.com/index
+#
+
+url='https://get.docker.com/'
+
+command_exists() {
+	command -v "$@" > /dev/null 2>&1
+}
+
+echo_docker_as_nonroot() {
+	if command_exists docker && [ -e /var/run/docker.sock ]; then
+		(
+			set -x
+			$sh_c 'docker version'
+		) || true
+	fi
+	your_user=your-user
+	[ "$user" != 'root' ] && your_user="$user"
+	# intentionally mixed spaces and tabs here -- tabs are stripped by "<<-EOF", spaces are kept in the output
+	cat <<-EOF
+
+	If you would like to use Docker as a non-root user, you should now consider
+	adding your user to the "docker" group with something like:
+
+	  sudo usermod -aG docker $your_user
+
+	Remember that you will have to log out and back in for this to take effect!
+
+	EOF
+}
+
+# Check if this is a forked Linux distro
+check_forked() {
+
+	# Check for lsb_release command existence, it usually exists in forked distros
+	if command_exists lsb_release; then
+		# Check if the `-u` option is supported
+		set +e
+		lsb_release -a -u > /dev/null 2>&1
+		lsb_release_exit_code=$?
+		set -e
+
+		# Check if the command has exited successfully, it means we're in a forked distro
+		if [ "$lsb_release_exit_code" = "0" ]; then
+			# Print info about current distro
+			cat <<-EOF
+			You're using '$lsb_dist' version '$dist_version'.
+			EOF
+
+			# Get the upstream release info
+			lsb_dist=$(lsb_release -a -u 2>&1 | tr '[:upper:]' '[:lower:]' | grep -E 'id' | cut -d ':' -f 2 | tr -d '[[:space:]]')
+			dist_version=$(lsb_release -a -u 2>&1 | tr '[:upper:]' '[:lower:]' | grep -E 'codename' | cut -d ':' -f 2 | tr -d '[[:space:]]')
+
+			# Print info about upstream distro
+			cat <<-EOF
+			Upstream release is '$lsb_dist' version '$dist_version'.
+			EOF
+		else
+			if [ -r /etc/debian_version ] && [ "$lsb_dist" != "ubuntu" ]; then
+				# We're Debian and don't even know it!
+				lsb_dist=debian
+				dist_version="$(cat /etc/debian_version | sed 's/\/.*//' | sed 's/\..*//')"
+				case "$dist_version" in
+					8|'Kali Linux 2')
+						dist_version="jessie"
+					;;
+					7)
+						dist_version="wheezy"
+					;;
+				esac
+			fi
+		fi
+	fi
+}
+
+rpm_import_repository_key() {
+	local key=$1; shift
+	local tmpdir=$(mktemp -d)
+	chmod 600 "$tmpdir"
+	gpg --homedir "$tmpdir" --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"
+	gpg --homedir "$tmpdir" --export --armor "$key" > "$tmpdir"/repo.key
+	rpm --import "$tmpdir"/repo.key
+	rm -rf "$tmpdir"
+}
+
+semverParse() {
+	major="${1%%.*}"
+	minor="${1#$major.}"
+	minor="${minor%%.*}"
+	patch="${1#$major.$minor.}"
+	patch="${patch%%[-.]*}"
+}
+
+do_install() {
+	case "$(uname -m)" in
+		*64)
+			;;
+		*)
+			cat >&2 <<-'EOF'
+			Error: you are not using a 64bit platform.
+			Docker currently only supports 64bit platforms.
+			EOF
+			exit 1
+			;;
+	esac
+
+	if command_exists docker; then
+		version="$(docker -v | awk -F '[ ,]+' '{ print $3 }')"
+		MAJOR_W=1
+		MINOR_W=10
+
+		semverParse $version
+
+		shouldWarn=0
+		if [ $major -lt $MAJOR_W ]; then
+			shouldWarn=1
+		fi
+
+		if [ $major -le $MAJOR_W ] && [ $minor -lt $MINOR_W ]; then
+			shouldWarn=1
+		fi
+
+		cat >&2 <<-'EOF'
+			Warning: the "docker" command appears to already exist on this system.
+
+			If you already have Docker installed, this script can cause trouble, which is
+			why we're displaying this warning and provide the opportunity to cancel the
+			installation.
+
+			If you installed the current Docker package using this script and are using it
+		EOF
+
+		if [ $shouldWarn -eq 1 ]; then
+			cat >&2 <<-'EOF'
+			again to update Docker, we urge you to migrate your image store before upgrading
+			to v1.10+.
+
+			You can find instructions for this here:
+			https://github.com/docker/docker/wiki/Engine-v1.10.0-content-addressability-migration
+			EOF
+		else
+			cat >&2 <<-'EOF'
+			again to update Docker, you can safely ignore this message.
+			EOF
+		fi
+
+		cat >&2 <<-'EOF'
+
+			You may press Ctrl+C now to abort this script.
+		EOF
+		( set -x; sleep 20 )
+	fi
+
+	user="$(id -un 2>/dev/null || true)"
+
+	sh_c='sh -c'
+	if [ "$user" != 'root' ]; then
+		if command_exists sudo; then
+			sh_c='sudo -E sh -c'
+		elif command_exists su; then
+			sh_c='su -c'
+		else
+			cat >&2 <<-'EOF'
+			Error: this installer needs the ability to run commands as root.
+			We are unable to find either "sudo" or "su" available to make this happen.
+			EOF
+			exit 1
+		fi
+	fi
+
+	curl=''
+	if command_exists curl; then
+		curl='curl -sSL'
+	elif command_exists wget; then
+		curl='wget -qO-'
+	elif command_exists busybox && busybox --list-modules | grep -q wget; then
+		curl='busybox wget -qO-'
+	fi
+
+	# check to see which repo they are trying to install from
+	repo='main'
+	if [ "https://test.docker.com/" = "$url" ]; then
+		repo='testing'
+	elif [ "https://experimental.docker.com/" = "$url" ]; then
+		repo='experimental'
+	fi
+
+	# perform some very rudimentary platform detection
+	lsb_dist=''
+	dist_version=''
+	if command_exists lsb_release; then
+		lsb_dist="$(lsb_release -si)"
+	fi
+	if [ -z "$lsb_dist" ] && [ -r /etc/lsb-release ]; then
+		lsb_dist="$(. /etc/lsb-release && echo "$DISTRIB_ID")"
+	fi
+	if [ -z "$lsb_dist" ] && [ -r /etc/debian_version ]; then
+		lsb_dist='debian'
+	fi
+	if [ -z "$lsb_dist" ] && [ -r /etc/fedora-release ]; then
+		lsb_dist='fedora'
+	fi
+	if [ -z "$lsb_dist" ] && [ -r /etc/oracle-release ]; then
+		lsb_dist='oracleserver'
+	fi
+	if [ -z "$lsb_dist" ]; then
+		if [ -r /etc/centos-release ] || [ -r /etc/redhat-release ]; then
+			lsb_dist='centos'
+		fi
+	fi
+	if [ -z "$lsb_dist" ] && [ -r /etc/os-release ]; then
+		lsb_dist="$(. /etc/os-release && echo "$ID")"
+	fi
+
+	lsb_dist="$(echo "$lsb_dist" | tr '[:upper:]' '[:lower:]')"
+
+	case "$lsb_dist" in
+
+		ubuntu)
+			if command_exists lsb_release; then
+				dist_version="$(lsb_release --codename | cut -f2)"
+			fi
+			if [ -z "$dist_version" ] && [ -r /etc/lsb-release ]; then
+				dist_version="$(. /etc/lsb-release && echo "$DISTRIB_CODENAME")"
+			fi
+		;;
+
+		debian)
+			dist_version="$(cat /etc/debian_version | sed 's/\/.*//' | sed 's/\..*//')"
+			case "$dist_version" in
+				8)
+					dist_version="jessie"
+				;;
+				7)
+					dist_version="wheezy"
+				;;
+			esac
+		;;
+
+		oracleserver)
+			# need to switch lsb_dist to match yum repo URL
+			lsb_dist="oraclelinux"
+			dist_version="$(rpm -q --whatprovides redhat-release --queryformat "%{VERSION}\n" | sed 's/\/.*//' | sed 's/\..*//' | sed 's/Server*//')"
+		;;
+
+		fedora|centos)
+			dist_version="$(rpm -q --whatprovides redhat-release --queryformat "%{VERSION}\n" | sed 's/\/.*//' | sed 's/\..*//' | sed 's/Server*//')"
+		;;
+
+		*)
+			if command_exists lsb_release; then
+				dist_version="$(lsb_release --codename | cut -f2)"
+			fi
+			if [ -z "$dist_version" ] && [ -r /etc/os-release ]; then
+				dist_version="$(. /etc/os-release && echo "$VERSION_ID")"
+			fi
+		;;
+
+
+	esac
+
+	# Check if this is a forked Linux distro
+	check_forked
+
+	# Run setup for each distro accordingly
+	case "$lsb_dist" in
+		amzn)
+			(
+			set -x
+			$sh_c 'sleep 3; yum -y -q install docker'
+			)
+			echo_docker_as_nonroot
+			exit 0
+			;;
+
+		'opensuse project'|opensuse)
+			echo 'Going to perform the following operations:'
+			if [ "$repo" != 'main' ]; then
+				echo '  * add repository obs://Virtualization:containers'
+			fi
+			echo '  * install Docker'
+			$sh_c 'echo "Press CTRL-C to abort"; sleep 3'
+
+			if [ "$repo" != 'main' ]; then
+				# install experimental packages from OBS://Virtualization:containers
+				(
+					set -x
+					zypper -n ar -f obs://Virtualization:containers Virtualization:containers
+					rpm_import_repository_key 55A0B34D49501BB7CA474F5AA193FBB572174FC2
+				)
+			fi
+			(
+				set -x
+				zypper -n install docker
+			)
+			echo_docker_as_nonroot
+			exit 0
+			;;
+		'suse linux'|sle[sd])
+			echo 'Going to perform the following operations:'
+			if [ "$repo" != 'main' ]; then
+				echo '  * add repository obs://Virtualization:containers'
+				echo '  * install experimental Docker using packages NOT supported by SUSE'
+			else
+				echo '  * add the "Containers" module'
+				echo '  * install Docker using packages supported by SUSE'
+			fi
+			$sh_c 'echo "Press CTRL-C to abort"; sleep 3'
+
+			if [ "$repo" != 'main' ]; then
+				# install experimental packages from OBS://Virtualization:containers
+				echo >&2 'Warning: installing experimental packages from OBS, these packages are NOT supported by SUSE'
+				(
+					set -x
+					zypper -n ar -f obs://Virtualization:containers/SLE_12 Virtualization:containers
+					rpm_import_repository_key 55A0B34D49501BB7CA474F5AA193FBB572174FC2
+				)
+			else
+				# Add the containers module
+				# Note well-1: the SLE machine must already be registered against SUSE Customer Center
+				# Note well-2: the `-r ""` is required to workaround a known issue of SUSEConnect
+				(
+					set -x
+					SUSEConnect -p sle-module-containers/12/x86_64 -r ""
+				)
+			fi
+			(
+				set -x
+				zypper -n install docker
+			)
+			echo_docker_as_nonroot
+			exit 0
+			;;
+
+		ubuntu|debian)
+			export DEBIAN_FRONTEND=noninteractive
+
+			did_apt_get_update=
+			apt_get_update() {
+				if [ -z "$did_apt_get_update" ]; then
+					( set -x; $sh_c 'sleep 3; apt-get update' )
+					did_apt_get_update=1
+				fi
+			}
+
+			# aufs is preferred over devicemapper; try to ensure the driver is available.
+			if ! grep -q aufs /proc/filesystems && ! $sh_c 'modprobe aufs'; then
+				if uname -r | grep -q -- '-generic' && dpkg -l 'linux-image-*-generic' | grep -qE '^ii|^hi' 2>/dev/null; then
+					kern_extras="linux-image-extra-$(uname -r) linux-image-extra-virtual"
+
+					apt_get_update
+					( set -x; $sh_c 'sleep 3; apt-get install -y -q '"$kern_extras" ) || true
+
+					if ! grep -q aufs /proc/filesystems && ! $sh_c 'modprobe aufs'; then
+						echo >&2 'Warning: tried to install '"$kern_extras"' (for AUFS)'
+						echo >&2 ' but we still have no AUFS.  Docker may not work. Proceeding anyways!'
+						( set -x; sleep 10 )
+					fi
+				else
+					echo >&2 'Warning: current kernel is not supported by the linux-image-extra-virtual'
+					echo >&2 ' package.  We have no AUFS support.  Consider installing the packages'
+					echo >&2 ' linux-image-virtual kernel and linux-image-extra-virtual for AUFS support.'
+					( set -x; sleep 10 )
+				fi
+			fi
+
+			# install apparmor utils if they're missing and apparmor is enabled in the kernel
+			# otherwise Docker will fail to start
+			if [ "$(cat /sys/module/apparmor/parameters/enabled 2>/dev/null)" = 'Y' ]; then
+				if command -v apparmor_parser >/dev/null 2>&1; then
+					echo 'apparmor is enabled in the kernel and apparmor utils were already installed'
+				else
+					echo 'apparmor is enabled in the kernel, but apparmor_parser missing'
+					apt_get_update
+					( set -x; $sh_c 'sleep 3; apt-get install -y -q apparmor' )
+				fi
+			fi
+
+			if [ ! -e /usr/lib/apt/methods/https ]; then
+				apt_get_update
+				( set -x; $sh_c 'sleep 3; apt-get install -y -q apt-transport-https ca-certificates' )
+			fi
+			if [ -z "$curl" ]; then
+				apt_get_update
+				( set -x; $sh_c 'sleep 3; apt-get install -y -q curl ca-certificates' )
+				curl='curl -sSL'
+			fi
+			(
+			set -x
+			$sh_c "apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D"
+			$sh_c "mkdir -p /etc/apt/sources.list.d"
+			$sh_c "echo deb [arch=$(dpkg --print-architecture)] https://apt.dockerproject.org/repo ${lsb_dist}-${dist_version} ${repo} > /etc/apt/sources.list.d/docker.list"
+			$sh_c 'sleep 3; apt-get update; apt-get install -y -q docker-engine'
+			)
+			echo_docker_as_nonroot
+			exit 0
+			;;
+
+		fedora|centos|oraclelinux)
+			$sh_c "cat >/etc/yum.repos.d/docker-${repo}.repo" <<-EOF
+			[docker-${repo}-repo]
+			name=Docker ${repo} Repository
+			baseurl=https://yum.dockerproject.org/repo/${repo}/${lsb_dist}/${dist_version}
+			enabled=1
+			gpgcheck=1
+			gpgkey=https://yum.dockerproject.org/gpg
+			EOF
+			if [ "$lsb_dist" = "fedora" ] && [ "$dist_version" -ge "22" ]; then
+				(
+					set -x
+					$sh_c 'sleep 3; dnf -y -q install docker-engine'
+				)
+			else
+				(
+					set -x
+					$sh_c 'sleep 3; yum -y -q install docker-engine'
+				)
+			fi
+			echo_docker_as_nonroot
+			exit 0
+			;;
+		gentoo)
+			if [ "$url" = "https://test.docker.com/" ]; then
+				# intentionally mixed spaces and tabs here -- tabs are stripped by "<<-'EOF'", spaces are kept in the output
+				cat >&2 <<-'EOF'
+
+				  You appear to be trying to install the latest nightly build in Gentoo.'
+				  The portage tree should contain the latest stable release of Docker, but'
+				  if you want something more recent, you can always use the live ebuild'
+				  provided in the "docker" overlay available via layman.  For more'
+				  instructions, please see the following URL:'
+
+				    https://github.com/tianon/docker-overlay#using-this-overlay'
+
+				  After adding the "docker" overlay, you should be able to:'
+
+				    emerge -av =app-emulation/docker-9999'
+
+				EOF
+				exit 1
+			fi
+
+			(
+				set -x
+				$sh_c 'sleep 3; emerge app-emulation/docker'
+			)
+			exit 0
+			;;
+	esac
+
+	# intentionally mixed spaces and tabs here -- tabs are stripped by "<<-'EOF'", spaces are kept in the output
+	cat >&2 <<-'EOF'
+
+	  Either your platform is not easily detectable, is not supported by this
+	  installer script (yet - PRs welcome! [hack/install.sh]), or does not yet have
+	  a package for Docker.  Please visit the following URL for more detailed
+	  installation instructions:
+
+	    https://docs.docker.com/engine/installation/
+
+	EOF
+	exit 1
+}
+
+# wrapped up in a function so that we have some protection against only getting
+# half the file during "curl | sh"
+do_install

--- a/src/main/docker/vpn/client/README
+++ b/src/main/docker/vpn/client/README
@@ -5,6 +5,8 @@ Follow the official guide here https://docs.docker.com/engine/installation/linux
 A script is provided to install Docker in ubuntu 14.04:
  - (in ubuntu 14.04) sudo sh install_docker.sh
 
+Modify "remote" property in client.conf file with the VPN server ip address.
+
 To build the client:
  - docker build -t vpn-client .
 

--- a/src/main/docker/vpn/client/README
+++ b/src/main/docker/vpn/client/README
@@ -2,8 +2,8 @@ Main Repository to track the VPN Integration with dockers
 
 To install Docker:
 Follow the official guide here https://docs.docker.com/engine/installation/linux/ubuntulinux/:
-A script is provided to install Docker in ubuntu 14.04:
- - (in ubuntu 14.04) sudo sh install_docker.sh
+A script is provided to install docker in any gnu-linux supported by docker:
+ - (in gnu-linux distro supported) sudo sh install_docker.sh
 
 Modify "remote" property in client.conf file with the VPN server ip address.
 

--- a/src/main/docker/vpn/client/README
+++ b/src/main/docker/vpn/client/README
@@ -1,9 +1,12 @@
 Main Repository to track the VPN Integration with dockers
 
-To build the client:
+To install Docker:
+Follow the official guide here https://docs.docker.com/engine/installation/linux/ubuntulinux/:
+A script is provided to install Docker in ubuntu 14.04:
+ - (in ubuntu 14.04) sudo sh install_docker.sh
 
+To build the client:
  - docker build -t vpn-client .
 
 To run the Docker:
  - docker run -t --net=host  --privileged -v /dev/net/:/dev/net/ vpn-client
-

--- a/src/main/docker/vpn/client/Vagrantfile
+++ b/src/main/docker/vpn/client/Vagrantfile
@@ -1,0 +1,74 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure(2) do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "ubuntu/trusty64"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Create a network interface bridged to eth0 in the host.
+  config.vm.network "public_network", :bridge => "eth0"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder ".", "/vpn-client-service-config"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
+  # such as FTP and Heroku are also available. See the documentation at
+  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
+  # config.push.define "atlas" do |push|
+  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
+  # end
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   sudo apt-get update
+  #   sudo apt-get install -y apache2
+  # SHELL
+end

--- a/src/main/docker/vpn/client/install_docker.sh
+++ b/src/main/docker/vpn/client/install_docker.sh
@@ -1,46 +1,21 @@
 #!/bin/bash
 
-#####################################
-## Install docker on ubuntu trusty ##
-#####################################
+#############################
+## Install docker on linux ##
+#############################
 
 # following the official guide here (accessed on 14/03/2016):
-# https://docs.docker.com/engine/installation/linux/ubuntulinux/
+# https://docs.docker.com/linux/step_one/
 
-echo "updating docker apt sources ..."
-
-# ensure that APT works with the https method, and that CA certificates are installed.
-apt-get update
-apt-get install apt-transport-https ca-certificates
-
-# Add docker PGP key
-apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
-
-# Add docker packages repo for ubuntu-trusty
-touch /etc/apt/sources.list.d/docker.list
-echo "deb https://apt.dockerproject.org/repo ubuntu-trusty main" > /etc/apt/sources.list.d/docker.list
-apt-get update
-
-# Uninstall old repo if it exists (it does not in the clean ubuntu/trusty64)
-apt-get purge lxc-docker
-
-
-echo "installing docker prerequisites ..."
-
-# For Ubuntu Trusty, it’s recommended to install the linux-image-extra kernel package.
-# The linux-image-extra package allows you use the aufs storage driver.
-apt-get install linux-image-extra-$(uname -r) -y
-
-# If you are installing on Ubuntu 14.04, apparmor is required (already installed in ubuntu/trusty64)
-apt-get install apparmor
+# Having curl installed is a requirement.
+# Must use OS dependent instructions to install it, before calling this script.
 
 echo "installing docker ..."
 
-# Install Docker
-apt-get update
-apt-get install docker-engine -y
+# Add Docker PGP key
+curl -fsSL https://get.docker.com/gpg | apt-key add -
 
-# Start docker daemon
-service docker start
+# Run Docker installation script
+curl -fsSL https://get.docker.com/ | sh
 
 echo "done installing docker."

--- a/src/main/docker/vpn/client/install_docker.sh
+++ b/src/main/docker/vpn/client/install_docker.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+#####################################
+## Install docker on ubuntu trusty ##
+#####################################
+
+# following the official guide here (accessed on 14/03/2016):
+# https://docs.docker.com/engine/installation/linux/ubuntulinux/
+
+echo "updating docker apt sources ..."
+
+# ensure that APT works with the https method, and that CA certificates are installed.
+apt-get update
+apt-get install apt-transport-https ca-certificates
+
+# Add docker PGP key
+apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+
+# Add docker packages repo for ubuntu-trusty
+touch /etc/apt/sources.list.d/docker.list
+echo "deb https://apt.dockerproject.org/repo ubuntu-trusty main" > /etc/apt/sources.list.d/docker.list
+apt-get update
+
+# Uninstall old repo if it exists (it does not in the clean ubuntu/trusty64)
+apt-get purge lxc-docker
+
+
+echo "installing docker prerequisites ..."
+
+# For Ubuntu Trusty, it’s recommended to install the linux-image-extra kernel package.
+# The linux-image-extra package allows you use the aufs storage driver.
+apt-get install linux-image-extra-$(uname -r) -y
+
+# If you are installing on Ubuntu 14.04, apparmor is required (already installed in ubuntu/trusty64)
+apt-get install apparmor
+
+echo "installing docker ..."
+
+# Install Docker
+apt-get update
+apt-get install docker-engine -y
+
+# Start docker daemon
+service docker start
+
+echo "done installing docker."

--- a/src/main/docker/vpn/server/README
+++ b/src/main/docker/vpn/server/README
@@ -1,5 +1,10 @@
 Main Repository to track the VPN Integration with dockers
 
+To install Docker:
+Follow the official guide here https://docs.docker.com/engine/installation/linux/ubuntulinux/:
+A script is provided to install Docker in ubuntu 14.04:
+ - (in ubuntu 14.04) sudo sh install_docker.sh
+
 To build the server:
  - docker build -t vpn-server .
 

--- a/src/main/docker/vpn/server/README
+++ b/src/main/docker/vpn/server/README
@@ -2,8 +2,8 @@ Main Repository to track the VPN Integration with dockers
 
 To install Docker:
 Follow the official guide here https://docs.docker.com/engine/installation/linux/ubuntulinux/:
-A script is provided to install Docker in ubuntu 14.04:
- - (in ubuntu 14.04) sudo sh install_docker.sh
+A script is provided to install docker in any gnu-linux supported by docker:
+ - (in gnu-linux distro supported) sudo sh install_docker.sh
 
 To build the server:
  - docker build -t vpn-server .

--- a/src/main/docker/vpn/server/Vagrantfile
+++ b/src/main/docker/vpn/server/Vagrantfile
@@ -1,0 +1,75 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure(2) do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "ubuntu/trusty64"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Create a network interface bridged to eth0 in the host.
+  config.vm.network "public_network", :bridge => "eth0"
+
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder ".", "/vpn-server-service-config"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
+  # such as FTP and Heroku are also available. See the documentation at
+  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
+  # config.push.define "atlas" do |push|
+  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
+  # end
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   sudo apt-get update
+  #   sudo apt-get install -y apache2
+  # SHELL
+end

--- a/src/main/docker/vpn/server/install_docker.sh
+++ b/src/main/docker/vpn/server/install_docker.sh
@@ -1,46 +1,21 @@
 #!/bin/bash
 
-#####################################
-## Install docker on ubuntu trusty ##
-#####################################
+#############################
+## Install docker on linux ##
+#############################
 
 # following the official guide here (accessed on 14/03/2016):
-# https://docs.docker.com/engine/installation/linux/ubuntulinux/
+# https://docs.docker.com/linux/step_one/
 
-echo "updating docker apt sources ..."
-
-# ensure that APT works with the https method, and that CA certificates are installed.
-apt-get update
-apt-get install apt-transport-https ca-certificates
-
-# Add docker PGP key
-apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
-
-# Add docker packages repo for ubuntu-trusty
-touch /etc/apt/sources.list.d/docker.list
-echo "deb https://apt.dockerproject.org/repo ubuntu-trusty main" > /etc/apt/sources.list.d/docker.list
-apt-get update
-
-# Uninstall old repo if it exists (it does not in the clean ubuntu/trusty64)
-apt-get purge lxc-docker
-
-
-echo "installing docker prerequisites ..."
-
-# For Ubuntu Trusty, it’s recommended to install the linux-image-extra kernel package.
-# The linux-image-extra package allows you use the aufs storage driver.
-apt-get install linux-image-extra-$(uname -r) -y
-
-# If you are installing on Ubuntu 14.04, apparmor is required (already installed in ubuntu/trusty64)
-apt-get install apparmor
+# Having curl installed is a requirement.
+# Must use OS dependent instructions to install it, before calling this script.
 
 echo "installing docker ..."
 
-# Install Docker
-apt-get update
-apt-get install docker-engine -y
+# Add Docker PGP key
+curl -fsSL https://get.docker.com/gpg | apt-key add -
 
-# Start docker daemon
-service docker start
+# Run Docker installation script
+curl -fsSL https://get.docker.com/ | sh
 
 echo "done installing docker."

--- a/src/main/docker/vpn/server/install_docker.sh
+++ b/src/main/docker/vpn/server/install_docker.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+#####################################
+## Install docker on ubuntu trusty ##
+#####################################
+
+# following the official guide here (accessed on 14/03/2016):
+# https://docs.docker.com/engine/installation/linux/ubuntulinux/
+
+echo "updating docker apt sources ..."
+
+# ensure that APT works with the https method, and that CA certificates are installed.
+apt-get update
+apt-get install apt-transport-https ca-certificates
+
+# Add docker PGP key
+apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+
+# Add docker packages repo for ubuntu-trusty
+touch /etc/apt/sources.list.d/docker.list
+echo "deb https://apt.dockerproject.org/repo ubuntu-trusty main" > /etc/apt/sources.list.d/docker.list
+apt-get update
+
+# Uninstall old repo if it exists (it does not in the clean ubuntu/trusty64)
+apt-get purge lxc-docker
+
+
+echo "installing docker prerequisites ..."
+
+# For Ubuntu Trusty, it’s recommended to install the linux-image-extra kernel package.
+# The linux-image-extra package allows you use the aufs storage driver.
+apt-get install linux-image-extra-$(uname -r) -y
+
+# If you are installing on Ubuntu 14.04, apparmor is required (already installed in ubuntu/trusty64)
+apt-get install apparmor
+
+echo "installing docker ..."
+
+# Install Docker
+apt-get update
+apt-get install docker-engine -y
+
+# Start docker daemon
+service docker start
+
+echo "done installing docker."


### PR DESCRIPTION
This patch provides scripts to install docker and vagrant files for fast deployment of the VPN components.

The docker installation script shall work in any gnu-linux distribution supported by docker.
It has been tested only in ubuntu-trusty.
