### PR TITLE
Allow specifying name for client certs.

### DIFF
--- a/src/main/docker/vpn/easy-rsa/gen_client.sh
+++ b/src/main/docker/vpn/easy-rsa/gen_client.sh
@@ -1,5 +1,14 @@
 echo -e "\nGenerating client certificate and keys.\n"
+
 srvname="client"
+while getopts u: option
+do
+        case "${option}"
+        in
+                u) srvname=${OPTARG};;
+        esac
+done
+
 echo -e "\nCreating $srvname"
 
 docker run -i --rm --name easy-rsa -v "$( cd "$( dirname "$0" )" && pwd )"/keys:/easy-rsa --env-file "$( cd "$( dirname "$0" )" && pwd )"/vars new-easy-rsa /er/build-key $srvname


### PR DESCRIPTION
This patch allows for specifying the name for the certificate and keys to be generated.
To specify the name, launch gen_client.sh with -u option. As in the following example:
`sh gen_client.sh -u client0`

It is required to fix the following issue:
Trying to generate multiple certs (and associated keys) with the same name issues an error, preventing the creation of the certificate. Only the first key pair and certificate for each name is created. Duplicated names produce the error below:
`failed to update database.
TXT_DB error number 2`

As a workaround, one may specify a different name for each client, which will produce for each call the files {name}.key, {name}.csr and {name}.crt and an entry in index.txt file.
