### PR TITLE
Force fw-docker entrypoint script to be executable

### DIFF
--- a/src/main/docker/fw/Dockerfile
+++ b/src/main/docker/fw/Dockerfile
@@ -6,5 +6,6 @@ RUN apk add -U \
   && rm -rf /var/cache/apk/*
 
 COPY ./sc-manager.py /usr/bin/
+RUN chmod +x /usr/bin/sc-manager.py
 
 ENTRYPOINT ["/usr/bin/sc-manager.py"]


### PR DESCRIPTION
This patch enforces that FW docker entrypoint script has has executable permission.

sc-manager.py may be downloaded without keeping the executable permission.
Although git maintains it, downloading the file via other methods (e.g. wget) may cause the file loosing executable permission which will prevent the docker run.

In order to enforce the permission is set, Dockerfile runs chmod +x in the entrypoint file inside the container.
