### PR TITLE
Fix/specific image version in dockerfiles

### DIFF
--- a/src/main/docker/vpn/client/Dockerfile
+++ b/src/main/docker/vpn/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:14.04
 
 RUN apt-get update
 RUN apt-get install -y openvpn

--- a/src/main/docker/vpn/client/README
+++ b/src/main/docker/vpn/client/README
@@ -12,3 +12,22 @@ To build the client:
 
 To run the Docker:
  - docker run -t --net=host  --privileged -v /dev/net/:/dev/net/ vpn-client
+
+A vagrant file is provided. It allows easily deploying the docker in a controlled environment (Ubuntu 14.04 VM).
+Deployed VM will have the content of this repository in /vpn-client-service-config/ directory.
+
+The following commands may be used to launch the docker container in the controlled environment using vagrant:
+
+vagrant up
+vagrant ssh
+cd /vpn-client-service-config/
+sudo su
+./install_docker.sh
+docker build -t vpn-client .
+docker run -t --net=host  --privileged -v /dev/net/:/dev/net/ vpn-client
+
+Once you are finished:
+^C
+exit
+exit
+vagrant destroy

--- a/src/main/docker/vpn/client/client.conf
+++ b/src/main/docker/vpn/client/client.conf
@@ -39,7 +39,7 @@ proto udp
 # The hostname/IP and port of the server.
 # You can have multiple remote entries
 # to load balance between the servers.
-remote 84.88.40.249 1194
+remote 192.168.1.131 1194
 ;remote my-server-2 1194
 
 # Choose a random host from the remote

--- a/src/main/docker/vpn/server/Dockerfile
+++ b/src/main/docker/vpn/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:14.04
 
 RUN apt-get update
 RUN apt-get install -y openvpn

--- a/src/main/docker/vpn/server/README
+++ b/src/main/docker/vpn/server/README
@@ -10,3 +10,22 @@ To build the server:
 
 To run the Docker:
  - docker run -t --net=host  --privileged -v /dev/net/:/dev/net/ vpn-server
+
+A vagrant file is provided. It allows easily deploying the docker in a controlled environment (Ubuntu 14.04 VM).
+Deployed VM will have the content of this repository in /vpn-server-service-config/ directory.
+
+The following commands may be used to launch the docker container in the controlled environment using vagrant:
+
+vagrant up
+vagrant ssh
+cd /vpn-server-service-config/
+sudo su
+./install_docker.sh
+docker build -t vpn-server .
+docker run -t --net=host  --privileged -v /dev/net/:/dev/net/ vpn-server
+
+Once you are finished:
+^C
+exit
+exit
+vagrant destroy


### PR DESCRIPTION
Force specific image version (ubuntu 14.04) in Dockerfile.

Different versions may cause script malfunction.
Specifically, it has been determined that using ubuntu/latest (as it it today)
Docker fails to run with the error:
/bin/sh: 1: sudo: not found

This patch avoids the error by staying in a version where
the run is known to work.
