### PR TITLE
"client.conf: not a directory" with docker 1.7.1

### DIFF
--- a/src/main/docker/vpn/client/Dockerfile
+++ b/src/main/docker/vpn/client/Dockerfile
@@ -3,11 +3,11 @@ FROM ubuntu:14.04
 RUN apt-get update
 RUN apt-get install -y openvpn
 
-COPY ./client.conf /etc/openvpn
-COPY ./client.crt /etc/openvpn
-COPY ./ca.crt /etc/openvpn
-COPY ./client.key /etc/openvpn
-COPY ./tun_manager.sh /etc/openvpn
+COPY ./client.conf /etc/openvpn/
+COPY ./client.crt /etc/openvpn/
+COPY ./ca.crt /etc/openvpn/
+COPY ./client.key /etc/openvpn/
+COPY ./tun_manager.sh /etc/openvpn/
 
 
 WORKDIR /etc/openvpn 


### PR DESCRIPTION
problem encountered on Docker version 1.7.1, build 786b29d/1.7.1
had to add / at the end to tell docker that the file should be copied in the folder and not over the folder
