### PR TITLE
FIlter by src/dst ip address

### DIFF
--- a/src/main/docker/fw/Dockerfile
+++ b/src/main/docker/fw/Dockerfile
@@ -6,6 +6,5 @@ RUN apk add -U \
   && rm -rf /var/cache/apk/*
 
 COPY ./sc-manager.py /usr/bin/
-RUN chmod +x /usr/bin/sc-manager.py
 
 ENTRYPOINT ["/usr/bin/sc-manager.py"]

--- a/src/main/docker/fw/Dockerfile
+++ b/src/main/docker/fw/Dockerfile
@@ -6,5 +6,6 @@ RUN apk add -U \
   && rm -rf /var/cache/apk/*
 
 COPY ./sc-manager.py /usr/bin/
+RUN chmod +x /usr/bin/sc-manager.py
 
 ENTRYPOINT ["/usr/bin/sc-manager.py"]

--- a/src/main/docker/fw/README
+++ b/src/main/docker/fw/README
@@ -1,18 +1,17 @@
-This Docker image manages iptables with a python wrapper.
+This Docker image manages iptables with a python wrapper. 
 
 To build the container:
  - docker build -t fw-docker .
 
-Run the docker with parameters :
-add/del in/out protocol destination-port ip address and drop/acpt
+To run the container and manage iptables:
+ - docker run -t --rm --net=host --privileged fw-docker add in tcp 8080 dest 1.1.1.1/27 drop
 
-When the container finishes running, it is automatically cleaned up and removed
-and one can see it has modified the iptables rules of the host.
-The container holds no state. State is maintained by iptables itself.
-Running the container has no other effect in the host than modifying host's iptables, and updating docker runs history.
+You can use the following keywords:
+---------------------------------------------------------------------------------------------------------
+| Add new rule:              add     Delete existing rule:   del     | Input:    in      Output:   out  |
+| Filter by Destination IP:  dest    Filter by Source IP:    source  | Accept:   acpt    Drop:     drop |
+---------------------------------------------------------------------------------------------------------
 
-To run the container making it add a rule to iptables:
- - docker run -t --rm --net=host --privileged fw-docker add in tcp 8080 1.1.1.1/27 drop
+Rule after the docker parameters must be written in this order:
+add/del in/out <protocol> <port> source/dest <ip> acpt/drop
 
-To run the container making it remove the previously added rule:
-- docker run -t --rm --net=host --privileged fw-docker del in tcp 8080 1.1.1.1/27 drop

--- a/src/main/docker/fw/sc-manager.py
+++ b/src/main/docker/fw/sc-manager.py
@@ -8,7 +8,7 @@ def usage():
     print "You can use the following keywoards:"
     print "---------------------------------------------------------------------------------------------------------------"
     print "| Add new rule: \t\tadd\tDelete existing rule:\tdel \t| Input:\tin\tOutput: out  |"
-    print "| Filter by Destination IP: \tdest\tFilter by Source IP:\tsource\t| Accept:\tacpt\tDrop:\tdrop |"
+    print "| Filter by Destination IP: \tdst\tFilter by Source IP:\tsrc\t| Accept:\tacpt\tDrop:\tdrop |"
     print "---------------------------------------------------------------------------------------------------------------"
     print "Rule must be written in this order:"
     print "add/del in/out <protocol> <port> dest/source <ip> acpt/drop"
@@ -18,7 +18,7 @@ def add_rule():
     action = '-A' if sys.argv[1] == 'add' else '-D' if sys.argv[1] == 'del' else usage()
     io = 'INPUT' if sys.argv[2] == 'in' else 'OUTPUT' if sys.argv[2] == 'out' else usage()
     accept = 'ACCEPT' if sys.argv[7] == 'acpt' else 'DROP' if sys.argv[7] == 'drop' else usage()
-    direction = '-s' if sys.argv[5] == 'source' else '-d' if sys.argv[5] == 'dest' else usage()
+    direction = '-s' if sys.argv[5] == 'src' else '-d' if sys.argv[5] == 'dst' else usage()
     opts = {'iptables': '/sbin/iptables', 'action': action, 'io': io, 'protocol': sys.argv[3], 'port': sys.argv[4], 'direction': direction,'ipAddress': sys.argv[6], 'accept': accept}
     ipcmd = '{iptables} {action} {io} -p {protocol} --dport {port} {direction} {ipAddress} -j {accept}'.format(**opts)
     print ipcmd

--- a/src/main/docker/fw/sc-manager.py
+++ b/src/main/docker/fw/sc-manager.py
@@ -4,21 +4,28 @@ import sys
 import os
 
 def usage():
-    print "Usage"
-    print "add/del in/out protocol port ip acpt/drop"
+    print "Usage:"
+    print "You can use the following keywoards:"
+    print "---------------------------------------------------------------------------------------------------------------"
+    print "| Add new rule: \t\tadd\tDelete existing rule:\tdel \t| Input:\tin\tOutput: out  |"
+    print "| Filter by Destination IP: \tdest\tFilter by Source IP:\tsource\t| Accept:\tacpt\tDrop:\tdrop |"
+    print "---------------------------------------------------------------------------------------------------------------"
+    print "Rule must be written in this order:"
+    print "add/del in/out <protocol> <port> dest/source <ip> acpt/drop"
     exit()
 
 def add_rule():
     action = '-A' if sys.argv[1] == 'add' else '-D' if sys.argv[1] == 'del' else usage()
     io = 'INPUT' if sys.argv[2] == 'in' else 'OUTPUT' if sys.argv[2] == 'out' else usage()
-    accept = 'ACCEPT' if sys.argv[6] == 'acpt' else 'DROP' if sys.argv[6] == 'drop' else usage()
-    opts = {'iptables': '/sbin/iptables', 'action': action, 'io': io, 'protocol': sys.argv[3], 'port': sys.argv[4], 'ipAddress': sys.argv[5], 'accept': accept}
-    ipcmd = '{iptables} {action} {io} -p {protocol} --dport {port} -d {ipAddress} -j {accept}'.format(**opts)
+    accept = 'ACCEPT' if sys.argv[7] == 'acpt' else 'DROP' if sys.argv[7] == 'drop' else usage()
+    direction = '-s' if sys.argv[5] == 'source' else '-d' if sys.argv[5] == 'dest' else usage()
+    opts = {'iptables': '/sbin/iptables', 'action': action, 'io': io, 'protocol': sys.argv[3], 'port': sys.argv[4], 'direction': direction,'ipAddress': sys.argv[6], 'accept': accept}
+    ipcmd = '{iptables} {action} {io} -p {protocol} --dport {port} {direction} {ipAddress} -j {accept}'.format(**opts)
     print ipcmd
     iptables = subprocess.call(ipcmd, shell=True)
 
 def main():
-    if len(sys.argv) != 7:
+    if len(sys.argv) != 8:
         usage()
     if not os.getuid() == 0:
         print "You must be root to change IPTables."


### PR DESCRIPTION
Allows the user to specify filtering either by source or by destination ip address.
Use either `src` or `dst` flags respectively.
