### PR TITLE
Feature/lb alpine

### DIFF
--- a/src/main/docker/lb/Dockerfile
+++ b/src/main/docker/lb/Dockerfile
@@ -1,11 +1,10 @@
-FROM ubuntu:14.04
+FROM alpine:3.4
 
-RUN \
-  sed -i 's/^# \(.*-backports\s\)/\1/g' /etc/apt/sources.list && \
-  apt-get update && \
-  apt-get install -y haproxy python && \
-  sed -i 's/^ENABLED=.*/ENABLED=1/' /etc/default/haproxy && \
-  rm -rf /var/lib/apt/lists/*
+RUN apk add -U \
+    haproxy \
+    python \
+    bash \
+  && rm -rf /var/cache/apk/*
 
 ADD haproxy.cfg /etc/haproxy/haproxy.cfg
 ADD start.bash /haproxy-start

--- a/src/main/docker/lb/README
+++ b/src/main/docker/lb/README
@@ -4,4 +4,4 @@ To build the container:
  - docker build -t lb-docker .
 
 To run the container and start load balancing incoming TCP connections:
- - docker docker run -t -d -p 8080:8080 -e COUCHDB_SERVERS=134.158.75.84:8080,134.158.75.85:8080 lb-docker
+ - docker run -t -d -p 8080:8080 -e COUCHDB_SERVERS=134.158.75.84:8080,134.158.75.85:8080 lb-docker

--- a/src/main/docker/lb/haproxy.cfg
+++ b/src/main/docker/lb/haproxy.cfg
@@ -6,9 +6,9 @@ defaults
         option redispatch
         retries 3
         maxconn 2000
-        contimeout      5000
-        clitimeout      50000
-        srvtimeout      50000
+        timeout connect      5000
+        timeout client      50000
+        timeout server      50000
 
 frontend lb
         bind 0.0.0.0:8080

--- a/src/main/docker/lb/haproxy.cfg
+++ b/src/main/docker/lb/haproxy.cfg
@@ -13,6 +13,7 @@ defaults
 frontend lb
         bind 0.0.0.0:8080
         mode tcp
+        option tcplog
         timeout client 3600s
         default_backend wordpress
 


### PR DESCRIPTION
Use Linux Alpine 3.4 as base image for LB docker container.

The container uses latest haproxy version for alpine available through apk, which today is haproxy  1.6.6.
This represents a significant update from the previously used in ubuntu (haproxy 1.4.24).
